### PR TITLE
use django<2 for building docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,5 @@ deps =
   1.8.X: Django>=1.8,<1.9
   1.10.X: Django>=1.10,<1.11
   1.11.X: Django>=1.11,<2
-  docs: django
+  docs: Django<2
   docs: sphinx


### PR DESCRIPTION
@orcasgit/orcas-developers This fixes the failing travis tests. Looks like the issue is that they were building with Django 2, which is not yet supported.